### PR TITLE
Copy tmux buffer to vim register in the same pane

### DIFF
--- a/plugin/vimtmuxclipboard.vim
+++ b/plugin/vimtmuxclipboard.vim
@@ -19,6 +19,14 @@ function! s:Enable()
     return
   endif
 
+  " These keeps last two tmux buffer names. If TmuxBufferName() and lastbname
+  " differ, this means tmux made some copies in other panes, creating new
+  " buffer(s). If these two are same, but lastbname and prevbname are
+  " different, this means tmux made a copy in the same pane: New buffer is
+  " created before FocusLost can accurately update lastbname. As a result,
+  " FocusLost sets lastbname to newly created buffer, instead of last one.
+  " Lastly, when vim is yanking to tmux buffer, prevbname is set to lastbname
+  " to avoid possible unnecessary copy in next FocusGain.
   let s:lastbname=""
   let s:prevbname=""
 

--- a/plugin/vimtmuxclipboard.vim
+++ b/plugin/vimtmuxclipboard.vim
@@ -1,57 +1,57 @@
 
 function! s:TmuxBufferName()
-	let l:list = systemlist('tmux list-buffers -F"#{buffer_name}"')
-	if len(l:list)==0
-		return ""
-	else
-		return l:list[0]
-	endif
+  let l:list = systemlist('tmux list-buffers -F"#{buffer_name}"')
+  if len(l:list)==0
+    return ""
+  else
+    return l:list[0]
+  endif
 endfunction
 
 function! s:TmuxBuffer()
-	return system('tmux show-buffer')
+  return system('tmux show-buffer')
 endfunction
 
 function! s:Enable()
 
-	if $TMUX=='' 
-		" not in tmux session
-		return
-	endif
+  if $TMUX==''
+    " not in tmux session
+    return
+  endif
 
-	let s:lastbname=""
+  let s:lastbname=""
 
-	" if support TextYankPost
-	if exists('##TextYankPost')==1
-		" @"
-		augroup vimtmuxclipboard
-			autocmd!
-			autocmd FocusLost * let s:lastbname=s:TmuxBufferName()
-			autocmd	FocusGained   * if s:lastbname!=s:TmuxBufferName() | let @" = s:TmuxBuffer() | endif
-			autocmd TextYankPost * silent! call system('tmux loadb -',join(v:event["regcontents"],"\n"))
-		augroup END
-		let @" = s:TmuxBuffer()
-	else
-		" vim doesn't support TextYankPost event
-		" This is a workaround for vim
-		augroup vimtmuxclipboard
-			autocmd!
-			autocmd FocusLost     *  silent! call system('tmux loadb -',@")
-			autocmd	FocusGained   *  let @" = s:TmuxBuffer()
-		augroup END
-		let @" = s:TmuxBuffer()
-	endif
+  " if support TextYankPost
+  if exists('##TextYankPost')==1
+    " @"
+    augroup vimtmuxclipboard
+      autocmd!
+      autocmd FocusLost * let s:lastbname=s:TmuxBufferName()
+      autocmd FocusGained * if s:lastbname!=s:TmuxBufferName() | let @" = s:TmuxBuffer() | endif
+      autocmd TextYankPost * silent! call system('tmux loadb -',join(v:event["regcontents"],"\n"))
+    augroup END
+    let @" = s:TmuxBuffer()
+  else
+    " vim doesn't support TextYankPost event
+    " This is a workaround for vim
+    augroup vimtmuxclipboard
+      autocmd!
+      autocmd FocusLost * silent! call system('tmux loadb -',@")
+      autocmd FocusGained * let @" = s:TmuxBuffer()
+    augroup END
+    let @" = s:TmuxBuffer()
+  endif
 
 endfunction
 
 call s:Enable()
 
-	" " workaround for this bug
-	" if shellescape("\n")=="'\\\n'"
-	" 	let l:s=substitute(l:s,'\\\n',"\n","g")
-	" 	let g:tmp_s=substitute(l:s,'\\\n',"\n","g")
-	" 	");
-	" 	let g:tmp_cmd='tmux set-buffer ' . l:s
-	" endif
-	" silent! call system('tmux loadb -',l:s)
+  " " workaround for this bug
+  " if shellescape("\n")=="'\\\n'"
+  "   let l:s=substitute(l:s,'\\\n',"\n","g")
+  "   let g:tmp_s=substitute(l:s,'\\\n',"\n","g")
+  "   ");
+  "   let g:tmp_cmd='tmux set-buffer ' . l:s
+  " endif
+  " silent! call system('tmux loadb -',l:s)
 

--- a/plugin/vimtmuxclipboard.vim
+++ b/plugin/vimtmuxclipboard.vim
@@ -20,15 +20,24 @@ function! s:Enable()
   endif
 
   let s:lastbname=""
+  let s:prevbname=""
 
   " if support TextYankPost
   if exists('##TextYankPost')==1
     " @"
     augroup vimtmuxclipboard
       autocmd!
-      autocmd FocusLost * let s:lastbname=s:TmuxBufferName()
-      autocmd FocusGained * if s:lastbname!=s:TmuxBufferName() | let @" = s:TmuxBuffer() | endif
-      autocmd TextYankPost * silent! call system('tmux loadb -',join(v:event["regcontents"],"\n"))
+      autocmd FocusLost    *
+        \ let s:prevbname = s:lastbname |
+        \ let s:lastbname = s:TmuxBufferName()
+      autocmd FocusGained  *
+        \ if s:lastbname != s:TmuxBufferName() || s:lastbname != s:prevbname |
+        \   let @" = s:TmuxBuffer() |
+        \ endif
+      autocmd TextYankPost *
+        \ silent! call system('tmux loadb -',join(v:event["regcontents"],"\n")) |
+        \ let s:lastbname = s:TmuxBufferName() |
+        \ let s:prevbname = s:lastbname |
     augroup END
     let @" = s:TmuxBuffer()
   else


### PR DESCRIPTION
Thank you for this useful plugin.

This PR allows copying tmux buffer to vim register where the vim instance running in the pane in which tmux buffer is modified, without any need of switching panes redundantly.

I needed to copy output of some commands run inside vim in the same pane with vim using tmux (as if I was using mouse). However, it didn't work as it did in different panes. I realized FocusLost is being called after tmux creates new buffer after it's done creating a new buffer to copy text in `<Prefix>[` mode. Therefore, FocusGain finds no difference between last buffer name and current buffer name. As a workaround, I kept track of the previous last buffer. See the inline comment and code for further information on how it works:

https://github.com/ozars/vim-tmux-clipboard/blob/f0a1ca23f91377527d18514a239aad6510bb796e/plugin/vimtmuxclipboard.vim#L22-L31

I expanded tab characters to spaces in the first commit, I can revert this if it's an issue.

My vim version:
```
VIM - Vi IMproved 8.1 (2018 May 18, compiled Nov 28 2018 01:38:28)
Included patches: 1-549
Modified by team+vim@tracker.debian.org
Compiled by team+vim@tracker.debian.org
Huge version with GTK3 GUI.  Features included (+) or not (-):
+acl               +extra_search      +mouse_netterm     +tag_old_static
+arabic            +farsi             +mouse_sgr         -tag_any_white
+autocmd           +file_in_path      -mouse_sysmouse    +tcl
+autochdir         +find_in_path      +mouse_urxvt       +termguicolors
-autoservername    +float             +mouse_xterm       +terminal
+balloon_eval      +folding           +multi_byte        +terminfo
+balloon_eval_term -footer            +multi_lang        +termresponse
+browse            +fork()            -mzscheme          +textobjects
++builtin_terms    +gettext           +netbeans_intg     +timers
+byte_offset       -hangul_input      +num64             +title
+channel           +iconv             +packages          +toolbar
+cindent           +insert_expand     +path_extra        +user_commands
+clientserver      +job               +perl              +vartabs
+clipboard         +jumplist          +persistent_undo   +vertsplit
+cmdline_compl     +keymap            +postscript        +virtualedit
+cmdline_hist      +lambda            +printer           +visual
+cmdline_info      +langmap           +profile           +visualextra
+comments          +libcall           -python            +viminfo
+conceal           +linebreak         +python3           +vreplace
+cryptv            +lispindent        +quickfix          +wildignore
+cscope            +listcmds          +reltime           +wildmenu
+cursorbind        +localmap          +rightleft         +windows
+cursorshape       +lua               +ruby              +writebackup
+dialog_con_gui    +menu              +scrollbind        +X11
+diff              +mksession         +signs             -xfontset
+digraphs          +modify_fname      +smartindent       +xim
+dnd               +mouse             +startuptime       +xpm
-ebcdic            +mouseshape        +statusline        +xsmp_interact
+emacs_tags        +mouse_dec         -sun_workshop      +xterm_clipboard
+eval              +mouse_gpm         +syntax            -xterm_save
+ex_extra          -mouse_jsbterm     +tag_binary
```