### PR TITLE
Asynchronously loads Tmux last buffer if Neovim's Job Control feature is available

### DIFF
--- a/plugin/vimtmuxclipboard.vim
+++ b/plugin/vimtmuxclipboard.vim
@@ -8,6 +8,14 @@ func! s:TmuxBufferName()
     endif
 endfunc
 
+function! s:on_stdout(job_id, data, event)
+    let @" = join(a:data, "\n")
+endfunction
+
+func! s:AsyncTmuxBuffer()
+    call jobstart('tmux show-buffer', {'on_stdout': function('s:on_stdout'), 'stdout_buffered': 1})
+endfunc
+
 func! s:TmuxBuffer()
     return system('tmux show-buffer')
 endfunc
@@ -29,8 +37,12 @@ func! s:Enable()
             autocmd FocusLost * call s:update_from_tmux()
             autocmd	FocusGained   * call s:update_from_tmux()
             autocmd TextYankPost * silent! call system('tmux loadb -',join(v:event["regcontents"],"\n"))
-            autocmd BufReadPost * silent! let @" = s:TmuxBuffer()
         augroup END
+        if exists('*jobstart')==1 " Only supported on Neovim
+            call s:AsyncTmuxBuffer()
+        else
+            let @" = s:TmuxBuffer()
+        endif
     else
         " vim doesn't support TextYankPost event
         " This is a workaround for vim
@@ -38,8 +50,8 @@ func! s:Enable()
             autocmd!
             autocmd FocusLost     *  silent! call system('tmux loadb -',@")
             autocmd	FocusGained   *  let @" = s:TmuxBuffer()
-            autocmd BufReadPost * silent! let @" = s:TmuxBuffer()
         augroup END
+        let @" = s:TmuxBuffer()
     endif
 
 endfunc

--- a/plugin/vimtmuxclipboard.vim
+++ b/plugin/vimtmuxclipboard.vim
@@ -29,8 +29,8 @@ func! s:Enable()
             autocmd FocusLost * call s:update_from_tmux()
             autocmd	FocusGained   * call s:update_from_tmux()
             autocmd TextYankPost * silent! call system('tmux loadb -',join(v:event["regcontents"],"\n"))
+            autocmd BufReadPost * silent! let @" = s:TmuxBuffer()
         augroup END
-        let @" = s:TmuxBuffer()
     else
         " vim doesn't support TextYankPost event
         " This is a workaround for vim
@@ -38,8 +38,8 @@ func! s:Enable()
             autocmd!
             autocmd FocusLost     *  silent! call system('tmux loadb -',@")
             autocmd	FocusGained   *  let @" = s:TmuxBuffer()
+            autocmd BufReadPost * silent! let @" = s:TmuxBuffer()
         augroup END
-        let @" = s:TmuxBuffer()
     endif
 
 endfunc


### PR DESCRIPTION
Partially address #6, because the improvement is only available if Neovim **Job Control** is supported.

# Performance comparison

```
$ nvim --startuptime /tmp/test.profile
```

## Without Neovim `jobstart` optimization

```
times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines
055.720  006.235  006.235: sourcing /Users/<user_name_here>/.local/share/nvim/plugged/vim-tmux-clipboard/plugin/vimtmuxclipboard.vim
```

## With Neovim `jobstart` optimization

```
times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines
033.792  000.393  000.393: sourcing /<path_to_my_local_version_of_plugin>/vim-tmux-clipboard/plugin/vimtmuxclipboard.vim
```

