### PR TITLE
Fix tmux loadb not copying

### DIFF
--- a/plugin/vimtmuxclipboard.vim
+++ b/plugin/vimtmuxclipboard.vim
@@ -28,7 +28,7 @@ func! s:Enable()
             autocmd!
             autocmd FocusLost * call s:update_from_tmux()
             autocmd	FocusGained   * call s:update_from_tmux()
-            autocmd TextYankPost * silent! call system('tmux loadb -',join(v:event["regcontents"],"\n"))
+            autocmd TextYankPost * silent! call system('tmux loadb -w -',join(v:event["regcontents"],"\n"))
         augroup END
         let @" = s:TmuxBuffer()
     else
@@ -36,7 +36,7 @@ func! s:Enable()
         " This is a workaround for vim
         augroup vimtmuxclipboard
             autocmd!
-            autocmd FocusLost     *  silent! call system('tmux loadb -',@")
+            autocmd FocusLost     *  silent! call system('tmux loadb -w -',@")
             autocmd	FocusGained   *  let @" = s:TmuxBuffer()
         augroup END
         let @" = s:TmuxBuffer()
@@ -61,4 +61,4 @@ call s:Enable()
 " 	");
 " 	let g:tmp_cmd='tmux set-buffer ' . l:s
 " endif
-" silent! call system('tmux loadb -',l:s)
+" silent! call system('tmux loadb -w -',l:s)


### PR DESCRIPTION
Per tmux manpage, loadb -w will copy through xterm control sequence. On one of my machines, the plain `echo hi | tmux loadb -` won't work, without `-w`.

tmux 3.2a
